### PR TITLE
검색시 join을 사용해서 모든 정보를 한번에 부르도록 함

### DIFF
--- a/cmd/roi/group_handler.go
+++ b/cmd/roi/group_handler.go
@@ -15,7 +15,7 @@ func addGroupHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		return addGroupPostHandler(w, r, env)
 	}
 	w.Header().Set("Cache-control", "no-cache")
-	cfg, err := roi.GetUserConfig(DB, env.User.ID())
+	cfg, err := roi.GetUserConfig(DB, env.User.ID)
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func addGroupHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		}
 	}
 	cfg.CurrentShow = show
-	err = roi.UpdateUserConfig(DB, env.User.ID(), cfg)
+	err = roi.UpdateUserState(DB, env.User.ID, cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/review_handler.go
+++ b/cmd/roi/review_handler.go
@@ -21,7 +21,7 @@ func reviewHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		}
 		return executeTemplate(w, "no-shows", recipe)
 	}
-	cfg, err := roi.GetUserConfig(DB, env.User.ID())
+	cfg, err := roi.GetUserConfig(DB, env.User.ID)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/root_handler.go
+++ b/cmd/roi/root_handler.go
@@ -11,6 +11,6 @@ func rootHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		http.Error(w, "page not found", http.StatusNotFound)
 		return nil
 	}
-	http.Redirect(w, r, "/user/"+env.User.ID(), http.StatusSeeOther)
+	http.Redirect(w, r, "/user/"+env.User.ID, http.StatusSeeOther)
 	return nil
 }

--- a/cmd/roi/show_handler.go
+++ b/cmd/roi/show_handler.go
@@ -88,12 +88,12 @@ func addShowPostHandler(w http.ResponseWriter, r *http.Request, env *Env) error 
 	if err != nil {
 		return err
 	}
-	cfg, err := roi.GetUserConfig(DB, env.User.ID())
+	cfg, err := roi.GetUserConfig(DB, env.User.ID)
 	if err != nil {
 		return err
 	}
 	cfg.CurrentShow = id
-	roi.UpdateUserConfig(DB, env.User.ID(), cfg)
+	roi.UpdateUserState(DB, env.User.ID, cfg)
 	http.Redirect(w, r, "/update-show?id="+id, http.StatusSeeOther)
 	return nil
 }

--- a/cmd/roi/task_handler.go
+++ b/cmd/roi/task_handler.go
@@ -255,8 +255,8 @@ func reviewTaskPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 		Task:    task,
 		Version: ver,
 		// 할일: 실제 리뷰어를 전달받도록 할 것.
-		Reviewer:  env.User.ID(),
-		Messenger: env.User.ID(),
+		Reviewer:  env.User.ID,
+		Messenger: env.User.ID,
 		Msg:       r.FormValue("msg"),
 		Status:    status,
 	}

--- a/cmd/roi/template.go
+++ b/cmd/roi/template.go
@@ -44,6 +44,7 @@ func parseTemplate() {
 		"sub":                 func(a, b int) int { return a - b },
 		"fieldJoin":           fieldJoin,
 		"spaceJoin":           func(words []string) string { return strings.Join(words, " ") },
+		"idJoin":              func(words ...string) string { return strings.Join(words, "/") },
 		"versionPreviewFiles": versionPreviewFiles,
 		"basename":            filepath.Base,
 	}

--- a/cmd/roi/tmpl/units.bml
+++ b/cmd/roi/tmpl/units.bml
@@ -59,12 +59,12 @@
 ]
 <div id="main-page"> [
 <!--검색 결과-->
-{{range $s := .Units}}
-<div class="unit" id="{{$s.ID}}"> [
+{{range $u := .Units}}
+<div class="unit" id="{{$u.ID}}"> [
 	<div class="unit-head" style="height:20px;display:flex;align-items:end;margin-bottom:4px;font-size:15px;"> [
 		<div class="ui" style="width:288px;margin-right:22px;display:flex;align-items:end;"> [
 				<div style="display:flex;flex-direction:column;"> [
-					<a href="/update-unit?id={{$s.ID}}" style="font-size:1.3rem;color:white;border-bottom:solid 1px var(--{{.Status.UIColor}});"> [
+					<a href="/update-unit?id={{$u.ID}}" style="font-size:1.3rem;color:white;border-bottom:solid 1px var(--{{.Status.UIColor}});"> [
 						<b> [{{.Group}}/{{.Unit}}]
 					]
 				]
@@ -75,18 +75,19 @@
 	]
 	<div class="unit-main" style="display:flex;margin-bottom:6px;"> [
 		<div style="margin-right:22px;"> [
-			{{if hasThumbnail $s.ID}}
-			<img class="thumbnail" style="width:288px;height:162px;" src="{{if hasThumbnail $s.ID}}/data/show/{{$s.ID}}/thumbnail.png{{end}}" onclick="selectUnit(this)" />
+			{{if hasThumbnail $u.ID}}
+			<img class="thumbnail" style="width:288px;height:162px;" src="{{if hasThumbnail $u.ID}}/data/show/{{$u.ID}}/thumbnail.png{{end}}" onclick="selectUnit(this)" />
 			{{else}}
 			<div class="thumbnail" style="box-sizing:border-box;width:288px;height:162px;color:#444444;background-color:#BBBBBB;font-size:12px;padding:4px;"  onclick="selectUnit(this)"> [{{.Description}}]
 			{{end}}
 		]
 		<div class="tasks"> [
-			{{range $i, $t := .Tasks}}
-			{{with index (index $.Tasks $s.Unit) $t}}
+			{{range $i, $t := $u.Tasks}}
+			{{with index $.Tasks (idJoin $u.ID $t)}}
+			{{$us := index $.Assignees .Assignee}}
 			<div class="task"> [
 				<div> [<a href="/update-task?id={{.ID}}" style="font-size:1.05rem;color:white;flex:1;">[{{.Task}}]]
-				<div> [<a href="/user/{{.Assignee}}" style="color:inherit">[{{.Assignee}}]]
+				<div> [<a href="/user/{{$us.ID}}" style="color:inherit">[{{$us.DisplayUserName}}]]
 				<div style="display:flex"> [
 					{{$i := 0}}
 					{{if .PublishVersion}}
@@ -121,7 +122,7 @@
 		]
 		<div class="unit-links"> [
 			{{if ne (len .Assets) 0 -}}
-			<a class="ui mini label" style="background-color:#977;color:white;" href="/units?show={{$s.Show}}&q={{spaceJoin .Assets}}"> [애셋 ({{fieldJoin .Assets}})]
+			<a class="ui mini label" style="background-color:#977;color:white;" href="/units?show={{$u.Show}}&q={{spaceJoin .Assets}}"> [애셋 ({{fieldJoin .Assets}})]
 			{{- end -}}
 			{{- range $i, $v := .Tags -}}
 			{{if ne $i 0}}{{end}}<a class="ui grey mini label" href="/units?q=tag%3A{{$v}}">{{$v}}</a>

--- a/cmd/roi/unit_handler.go
+++ b/cmd/roi/unit_handler.go
@@ -13,7 +13,7 @@ func addUnitHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		return addUnitPostHandler(w, r, env)
 	}
 	w.Header().Set("Cache-control", "no-cache")
-	cfg, err := roi.GetUserConfig(DB, env.User.ID())
+	cfg, err := roi.GetUserConfig(DB, env.User.ID)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func addUnitHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		return err
 	}
 	cfg.CurrentShow = id
-	err = roi.UpdateUserConfig(DB, env.User.ID(), cfg)
+	err = roi.UpdateUserState(DB, env.User.ID, cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/roi/user_handler.go
+++ b/cmd/roi/user_handler.go
@@ -208,7 +208,7 @@ func signupHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 func profileHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 	if r.Method == "POST" {
 		id := r.FormValue("id")
-		if env.User.ID() != id {
+		if env.User.ID != id {
 			return roi.BadRequest("not allowed to change other's profile")
 		}
 		u, err := roi.GetUser(DB, id)
@@ -256,14 +256,14 @@ func updatePasswordHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 	if newpw != newpwc {
 		return roi.BadRequest("passwords are not matched")
 	}
-	match, err := roi.UserPasswordMatch(DB, env.User.ID(), oldpw)
+	match, err := roi.UserPasswordMatch(DB, env.User.ID, oldpw)
 	if err != nil {
 		return err
 	}
 	if !match {
 		return roi.BadRequest("entered password is not correct")
 	}
-	err = roi.UpdateUserPassword(DB, env.User.ID(), newpw)
+	err = roi.UpdateUserPassword(DB, env.User.ID, newpw)
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func userHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 	})
 	taskFromID := make(map[string]*roi.Task)
 	for _, t := range tasks {
-		taskFromID[env.User.ID()] = t
+		taskFromID[env.User.ID] = t
 	}
 	tasksOfDay := make(map[string][]string, 28)
 	for _, t := range tasks {
@@ -321,7 +321,7 @@ func userHandler(w http.ResponseWriter, r *http.Request, env *Env) error {
 		if tasksOfDay[due] == nil {
 			tasksOfDay[due] = make([]string, 0)
 		}
-		tasksOfDay[due] = append(tasksOfDay[due], env.User.ID())
+		tasksOfDay[due] = append(tasksOfDay[due], env.User.ID)
 	}
 	// 앞으로 4주에 대한 태스크 정보를 보인다.
 	// 총 기간이나 단위는 추후 설정할 수 있도록 할 것.

--- a/cmd/roi/version_handler.go
+++ b/cmd/roi/version_handler.go
@@ -53,7 +53,7 @@ func addVersionPostHandler(w http.ResponseWriter, r *http.Request, env *Env) err
 		Unit:    unit,
 		Task:    task,
 		Version: version,
-		Owner:   env.User.ID(),
+		Owner:   env.User.ID,
 	}
 	err = roi.AddVersion(DB, v)
 	if err != nil {

--- a/unit_test.go
+++ b/unit_test.go
@@ -61,7 +61,11 @@ var testUnitC = &Unit{
 	},
 }
 
-var testUnits = []*Unit{testUnitA, testUnitB, testUnitC}
+var testUnits = map[string]*Unit{
+	testUnitA.ID(): testUnitA,
+	testUnitB.ID(): testUnitB,
+	testUnitC.ID(): testUnitC,
+}
 
 func TestUnit(t *testing.T) {
 	want := testUnits
@@ -118,7 +122,7 @@ func TestUnit(t *testing.T) {
 		}
 	}
 
-	got, err := SearchUnits(db, testShow.Show, []string{}, []string{}, "", "", "", "", "", time.Time{})
+	got, _, _, err := SearchUnits(db, testShow.Show, []string{}, []string{}, "", "", "", "", "", time.Time{})
 	if err != nil {
 		t.Fatalf("could not search units from units table: %s", err)
 	}
@@ -129,19 +133,24 @@ func TestUnit(t *testing.T) {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}
 
-	got, err = SearchUnits(db, testShow.Show, []string{"CG"}, []string{"0010"}, "", "", "", "", "", time.Time{})
+	got, _, _, err = SearchUnits(db, testShow.Show, []string{"CG"}, []string{"0010"}, "", "", "", "", "", time.Time{})
 	if err != nil {
 		t.Fatalf("could not search units from units table: %s", err)
 	}
-	want = []*Unit{testUnitA}
+	want = map[string]*Unit{
+		testUnitA.ID(): testUnitA,
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}
-	got, err = SearchUnits(db, testShow.Show, []string{}, []string{}, "로이", "", "", "", "", time.Time{})
+	got, _, _, err = SearchUnits(db, testShow.Show, []string{}, []string{}, "로이", "", "", "", "", time.Time{})
 	if err != nil {
 		t.Fatalf("could not search units from units table: %s", err)
 	}
-	want = []*Unit{testUnitA, testUnitB}
+	want = map[string]*Unit{
+		testUnitA.ID(): testUnitA,
+		testUnitB.ID(): testUnitB,
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}

--- a/user.go
+++ b/user.go
@@ -10,8 +10,9 @@ import (
 )
 
 var CreateTableIfNotExistsUsersStmt = `CREATE TABLE IF NOT EXISTS users (
-	username STRING UNIQUE NOT NULL CHECK (length(username) > 0) CHECK (username NOT LIKE '% %'),
-	domain STRING UNIQUE NOT NULL,
+	id STRING UNIQUE NOT NULL CHECK (length(id) > 0) CHECK (id NOT LIKE '% %'),
+	username STRING NOT NULL CHECK (length(username) > 0) CHECK (username NOT LIKE '% %'),
+	domain STRING NOT NULL,
 	display_name STRING NOT NULL,
 	team STRING NOT NULL,
 	role STRING NOT NULL,
@@ -20,32 +21,19 @@ var CreateTableIfNotExistsUsersStmt = `CREATE TABLE IF NOT EXISTS users (
 	entry_date STRING NOT NULL,
 	hashed_password STRING NOT NULL,
 	current_show STRING NOT NULL,
-	CONSTRAINT users_pk PRIMARY KEY (username, domain)
+	CONSTRAINT users_pk PRIMARY KEY (id)
 )`
 
-// userInfo는 db에 저장하는 사용자 전체 정보이다.
-type userInfo struct {
-	User        string `db:"username"`
-	Domain      string `db:"domain"`
-	DisplayName string `db:"display_name"`
-	Team        string `db:"team"`
-	Role        string `db:"role"`
-	Email       string `db:"email"`
-	PhoneNumber string `db:"phone_number"`
-	EntryDate   string `db:"entry_date"`
-
-	HashedPassword string `db:"hashed_password"`
-
-	// 설정
-	CurrentShow string `db:"current_show"`
-}
-
-var userdbkey string = strings.Join(dbKeys(&userInfo{}), ", ")
-var userdbidx string = strings.Join(dbIdxs(&userInfo{}), ", ")
-var _ []interface{} = dbVals(&userInfo{})
+var userAllDBKey string = strings.Join(dbKeys(&User{}, &userPassword{}, &UserState{}), ", ")
+var userAllDBIdx string = strings.Join(dbIdxs(&User{}, &userPassword{}, &UserState{}), ", ")
+var _ []interface{} = dbVals(&User{}, &userPassword{}, &UserState{})
 
 // User는 일반적인 사용자 정보이다.
 type User struct {
+	// ID는 DB에 저장되기 전 항상 User와 Domain을 통해 업데이트 된다.
+	// 이 필드를 수정하지 말 것.
+	ID string `db:"id"`
+
 	// 도메인이 존재한다면 OIDC 유저, 그렇지 않다면 로컬 유저이다.
 	User   string `db:"username"`
 	Domain string `db:"domain"`
@@ -60,15 +48,6 @@ type User struct {
 
 var userDBKey string = strings.Join(dbKeys(&User{}), ", ")
 var userDBIdx string = strings.Join(dbIdxs(&User{}), ", ")
-var _ []interface{} = dbVals(&User{})
-
-// ID는 사용자의 아이디를 반환한다.
-func (u *User) ID() string {
-	if u.Domain != "" {
-		return u.User + "@" + u.Domain
-	}
-	return u.User
-}
 
 // DisplayUserName은 웹에서 표시될 사용자의 이름을 반환한다.
 //
@@ -82,6 +61,20 @@ func (u *User) DisplayUserName() string {
 	}
 	return u.User
 }
+
+type userPassword struct {
+	HashedPassword string `db:"hashed_password"`
+}
+
+var userPasswordDBKey string = strings.Join(dbKeys(&userPassword{}), ", ")
+var userPasswordDBIdx string = strings.Join(dbIdxs(&userPassword{}), ", ")
+
+type UserState struct {
+	CurrentShow string `db:"current_show"`
+}
+
+var userStateDBKey string = strings.Join(dbKeys(&UserState{}), ", ")
+var userStateDBIdx string = strings.Join(dbIdxs(&UserState{}), ", ")
 
 // splitUserID는 사용자 아이디에서 유저이름과 도메인을 분리한다.
 // 받아들인 아이디가 지원하지 않는 형식이라면 에러를 반환한다.
@@ -137,6 +130,28 @@ func verifyUserPassword(pw string) error {
 	return nil
 }
 
+// verifyUser는 받아들인 사용자가 유효하지 않다면 에러를 반환한다.
+// 필요하다면 db의 정보와 비교하거나 유효성 확보를 위해 정보를 수정한다.
+func verifyUser(db *sql.DB, u *User) error {
+	if u == nil {
+		return fmt.Errorf("nil user")
+	}
+	err := verifyUserName(u.User)
+	if err != nil {
+		return err
+	}
+	err = verifyUserDomain(u.Domain)
+	if err != nil {
+		return err
+	}
+	// 아이디 생성
+	u.ID = u.User
+	if u.Domain != "" {
+		u.ID = u.User + "@" + u.Domain
+	}
+	return nil
+}
+
 // AddUser는 db에 한 명의 사용자를 추가한다.
 func AddUser(db *sql.DB, id, pw string) error {
 	user, domain, err := splitUserID(id)
@@ -158,6 +173,10 @@ func AddUser(db *sql.DB, id, pw string) error {
 	hashed_password := ""
 	if domain == "" {
 		// 로컬 사용자
+		err = verifyUserPassword(pw)
+		if err != nil {
+			return err
+		}
 		hashed, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.DefaultCost)
 		if err != nil {
 			return err
@@ -165,9 +184,15 @@ func AddUser(db *sql.DB, id, pw string) error {
 		hashed_password = string(hashed)
 	}
 	// 사용자 생성
-	u := &userInfo{User: user, Domain: domain, HashedPassword: hashed_password}
+	u := &User{User: user, Domain: domain}
+	err = verifyUser(db, u)
+	if err != nil {
+		return err
+	}
+	up := &userPassword{HashedPassword: hashed_password}
+	us := &UserState{}
 	stmts := []dbStatement{
-		dbStmt(fmt.Sprintf("INSERT INTO users (%s) VALUES (%s)", userdbkey, userdbidx), dbVals(u)...),
+		dbStmt(fmt.Sprintf("INSERT INTO users (%s) VALUES (%s)", userAllDBKey, userAllDBIdx), dbVals(u, up, us)...),
 	}
 	return dbExec(db, stmts)
 }
@@ -250,28 +275,24 @@ func UpdateUser(db *sql.DB, id string, u *User) error {
 	if err != nil {
 		return err
 	}
+	err = verifyUser(db, u)
+	if err != nil {
+		return err
+	}
 	stmts := []dbStatement{
 		dbStmt(fmt.Sprintf("UPDATE users SET (%s) = (%s) WHERE username='%s' AND domain='%s'", userDBKey, userDBIdx, user, domain), dbVals(u)...),
 	}
 	return dbExec(db, stmts)
 }
 
-type UserConfig struct {
-	CurrentShow string `db:"current_show"`
-}
-
-var userConfigDBKey string = strings.Join(dbKeys(&UserConfig{}), ", ")
-var userConfigDBIdx string = strings.Join(dbIdxs(&UserConfig{}), ", ")
-var _ []interface{} = dbVals(&UserConfig{})
-
 // UpdateUserConfig는 유저의 설정 값들을 받아온다.
-func GetUserConfig(db *sql.DB, id string) (*UserConfig, error) {
+func GetUserConfig(db *sql.DB, id string) (*UserState, error) {
 	user, domain, err := splitUserID(id)
 	if err != nil {
 		return nil, err
 	}
-	stmt := dbStmt(fmt.Sprintf("SELECT %s FROM users WHERE username='%s' AND domain='%s'", userConfigDBKey, user, domain))
-	u := &UserConfig{}
+	stmt := dbStmt(fmt.Sprintf("SELECT %s FROM users WHERE username='%s' AND domain='%s'", userStateDBKey, user, domain))
+	u := &UserState{}
 	err = dbQueryRow(db, stmt, func(row *sql.Row) error {
 		return scan(row, u)
 	})
@@ -284,8 +305,8 @@ func GetUserConfig(db *sql.DB, id string) (*UserConfig, error) {
 	return u, nil
 }
 
-// UpdateUserConfig는 유저의 설정 값들을 업데이트 한다.
-func UpdateUserConfig(db *sql.DB, id string, u *UserConfig) error {
+// UpdateUserState는 유저의 설정 값들을 업데이트 한다.
+func UpdateUserState(db *sql.DB, id string, u *UserState) error {
 	if u == nil {
 		return BadRequest("user config shold not nil")
 	}
@@ -294,7 +315,7 @@ func UpdateUserConfig(db *sql.DB, id string, u *UserConfig) error {
 		return err
 	}
 	stmts := []dbStatement{
-		dbStmt(fmt.Sprintf("UPDATE users SET (%s) = (%s) WHERE username='%s' AND domain='%s'", userConfigDBKey, userConfigDBIdx, user, domain), dbVals(u)...),
+		dbStmt(fmt.Sprintf("UPDATE users SET (%s) = (%s) WHERE username='%s' AND domain='%s'", userStateDBKey, userStateDBIdx, user, domain), dbVals(u)...),
 	}
 	return dbExec(db, stmts)
 }

--- a/user_test.go
+++ b/user_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestUser(t *testing.T) {
 	u := &User{
+		ID:          "kybin",
 		User:        "kybin",
 		Domain:      "",
 		DisplayName: "김용빈",
@@ -32,15 +33,15 @@ func TestUser(t *testing.T) {
 			t.Fatalf("could not delete site: %s", err)
 		}
 	}()
-	err = AddUser(db, u.ID(), password)
+	err = AddUser(db, u.ID, password)
 	if err != nil {
 		t.Fatalf("could not add user: %s", err)
 	}
-	err = UpdateUser(db, u.ID(), u)
+	err = UpdateUser(db, u.ID, u)
 	if err != nil {
 		t.Fatalf("could not update user: %v", err)
 	}
-	got, err := GetUser(db, u.ID())
+	got, err := GetUser(db, u.ID)
 	if err != nil {
 		t.Fatalf("could not get user: %v", err)
 	}
@@ -48,18 +49,18 @@ func TestUser(t *testing.T) {
 		t.Fatalf("user not match: got: %v, want: %v", got, u)
 	}
 	new_password := "this is not my password neither"
-	err = UpdateUserPassword(db, u.ID(), new_password)
+	err = UpdateUserPassword(db, u.ID, new_password)
 	if err != nil {
 		t.Fatalf("could not update user password: %v", err)
 	}
-	ok, err := UserPasswordMatch(db, u.ID(), new_password)
+	ok, err := UserPasswordMatch(db, u.ID, new_password)
 	if err != nil {
 		t.Fatalf("could not check user password match: %v", err)
 	}
 	if !ok {
 		t.Fatalf("user password not match: %v", err)
 	}
-	err = DeleteUser(db, u.ID())
+	err = DeleteUser(db, u.ID)
 	if err != nil {
 		t.Fatalf("could not delete user: %v", err)
 	}


### PR DESCRIPTION
join을 이용하고 난 뒤 체감상 많이 빨라졌지만 안타깝게도
이를 수치로 확인해보지는 못했다.

userInfo 스트럭트를 User, userPassword, UserState로
분리하였고, 이 분리된 스트럭트에 대한 db 키, 값, 인덱스를
한번에 받을 수 있도록 db관련 함수를 변경하였다.

또한 join을 위해 tasks.assignee와 users.id의 비교가 필요해짐에
따라 ID 필드를 되살리는 대신 DB에 업데이트시 verifyUser를 통해
User와 Domain 필드를 이용하여 자동으로 업데이트 되도록 하였다.